### PR TITLE
Add iocextract to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An [awesome](https://github.com/sindresorhus/awesome) collection of indicators o
 - [yahoo/PyIOCe](https://github.com/yahoo/PyIOCe)
 - [mandiant/ioc_writer](https://github.com/mandiant/ioc_writer)
 - [Neo23x0/yarGen](https://github.com/Neo23x0/yarGen)
+- [InQuest/iocextract](https://github.com/inquest/python-iocextract)
 
 ### IOC Formats
 


### PR DESCRIPTION
Adding https://github.com/inquest/python-iocextract to the Tools section.

I see "This should focus on indicators and less on tools" in the contributing guidelines, so no worries if you don't want to merge this. :)